### PR TITLE
Add support for specifying Dockerfile name

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ This repo provides a utility GitHub action for the [CI Workflow](https://github.
 * `DOCKER_FOLDER` (optional, defaults to './') - folder where Dockerfile is in; needs a trailing slash
 * `VERSION` - semantic version used as the tag for the resulting image
 * `DATETIME` (optional) - in case you want to build multiple images and refer to them with the same datetime string, e.g., YYYYMMDDHHmmss; (defaults to `DATETIME=$(date +'%Y%m%d%H%M')`) 
+* `FILE` (optional, defaults to 'Dockerfile') - name of the Dockerfile
 
 ## Outputs
 
@@ -69,4 +70,5 @@ None at the moment
           VERSION: ${{ env.VERSION }}
           IMAGE_NAME: "yourdockerorg/yourimagename"
           DOCKER_FOLDER: "your-sub-directory/"
+          FILE: "your-dockerfile.Dockerfile"
 ```

--- a/action.yml
+++ b/action.yml
@@ -14,6 +14,9 @@ inputs:
   DATETIME:
     description: Optional datetime for the tag of the docker image (will be set automatically if left empty)
     default: unset
+  FILE:
+    description: Optional name of the Dockerfile
+    default: 'Dockerfile'
 runs:
   using: composite
   steps: 
@@ -71,4 +74,5 @@ runs:
         DOCKER_FOLDER: ${{ inputs.DOCKER_FOLDER }}
         VERSION: ${{ inputs.VERSION }}
         DATETIME: ${{ steps.check_datetime.outputs.DATETIME }}
-      run: ${{ github.action_path }}/build_docker_image.sh "${IMAGE_NAME}" "${DOCKER_FOLDER}" "${VERSION}" "${DATETIME}"
+        FILE: ${{ inputs.FILE }}
+      run: ${{ github.action_path }}/build_docker_image.sh "${IMAGE_NAME}" "${DOCKER_FOLDER}" "${VERSION}" "${DATETIME}" "${FILE}"

--- a/build_docker_image.sh
+++ b/build_docker_image.sh
@@ -1,18 +1,19 @@
 #!/bin/bash
 
-if [[ "$#" -ne 4 ]]; then
-  echo "Usage: $0 IMAGE FOLDER VERSION DATETIME"
-  echo "      Example: $0 keptn/api api/ 1.2.3 20210101101210"
+if [[ "$#" -ne 5 ]]; then
+  echo "Usage: $0 IMAGE FOLDER VERSION DATETIME FILE"
+  echo "      Example: $0 keptn/api api/ 1.2.3 20210101101210 Dockerfile"
   echo "      Your command: $0 $*"
   exit 1
 fi
 
 # todo: not sure if we can use parameters like this
-# ${IMAGE}=$1 ${FOLDER}=$2 ${VERSION}=$3 ${DATETIME}=$4
+# ${IMAGE}=$1 ${FOLDER}=$2 ${VERSION}=$3 ${DATETIME}=$4 ${FILE}=$5
 IMAGE=$1
 FOLDER=$2
 VERSION=$3
 DATETIME=$4
+FILE=$5
 
 # store pwd
 pwd=$(pwd)
@@ -24,21 +25,21 @@ if [[ "${FOLDER}" != */ ]]; then
 fi
 
 # ToDo: Where do we get the Manifest from?
-echo "Building Docker Image ${IMAGE}:${VERSION}.${DATETIME} from ${FOLDER}DOCKERFILE"
+echo "Building Docker Image ${IMAGE}:${VERSION}.${DATETIME} from ${FOLDER}${FILE}"
 
 # change into the subfolder where the needed files are hosted
 cd ./${FOLDER}
 
 # uncomment certain lines from Dockerfile that are for CI builds only
-sed -i '/#travis-uncomment/s/^#travis-uncomment //g' Dockerfile
-sed -i '/#build-uncomment/s/^#build-uncomment //g' Dockerfile
+sed -i '/#travis-uncomment/s/^#travis-uncomment //g' ${FILE}
+sed -i '/#build-uncomment/s/^#build-uncomment //g' ${FILE}
 cat MANIFEST
 
-docker build . -t "${IMAGE}:${VERSION}.${DATETIME}" -t "${IMAGE}:${VERSION}" --build-arg version="${VERSION}"
+docker build . -f "${FILE}" -t "${IMAGE}:${VERSION}.${DATETIME}" -t "${IMAGE}:${VERSION}" --build-arg version="${VERSION}"
 
 if [[ $? -ne 0 ]]; then
   echo "Failed to build Docker Image ${IMAGE}:${VERSION}.${DATETIME}, exiting"
-  echo "::error file=${FOLDER}/Dockerfile::Failed to build Docker Image"
+  echo "::error file=${FOLDER}/${FILE}::Failed to build Docker Image"
   exit 1
 fi
 
@@ -46,7 +47,7 @@ fi
 docker push "${IMAGE}:${VERSION}.${DATETIME}" && docker push "${IMAGE}:${VERSION}"
 
 if [[ $? -ne 0 ]]; then
-  echo "::warning file=${FOLDER}/Dockerfile::Failed to push ${IMAGE}:${VERSION}.${DATETIME} to DockerHub, continuing anyway"
+  echo "::warning file=${FOLDER}/${FILE}::Failed to push ${IMAGE}:${VERSION}.${DATETIME} to DockerHub, continuing anyway"
   echo "* Failed to push ${IMAGE}:${VERSION}.${DATETIME} and ${IMAGE}:${VERSION} (Source: ${FOLDER})" >> ${pwd}/docker_build_report.txt
 else
   echo "* Pushed ${IMAGE}:${VERSION}.${DATETIME} and ${IMAGE}:${VERSION} (Source: ${FOLDER})" >> ${pwd}/docker_build_report.txt


### PR DESCRIPTION
We would need this for our service (https://github.com/didiladi/keptn-generic-job-service), where we have multiple Dockerfiles with different names in the same directory. A successful CI run with the changes can be found here: https://github.com/didiladi/keptn-generic-job-service/pull/21/checks?check_run_id=2673152033